### PR TITLE
Fix type annotation

### DIFF
--- a/shipyard/passes/insert_ct_waveforms.py
+++ b/shipyard/passes/insert_ct_waveforms.py
@@ -27,7 +27,7 @@ class InsertCTWaveforms(QASMTransformer):
 
     @staticmethod
     def add_assignWaveIndex(
-        waveform_set: set(tuple[int, int])
+        waveform_set: set[tuple[int, int]]
     ) -> ast.CalibrationStatement:
         """
         Create list of openQASM statements to of


### PR DESCRIPTION
I tried installing Shipyard and running the unit tests. I am on `Python 3.10.8`. I encountered the following error

```
shipyard/passes/insert_ct_waveforms.py:30: in InsertCTWaveforms
    waveform_set: set(tuple[int, int])
E   TypeError: 'types.GenericAlias' object is not iterable
```

The issue is that `set(tuple[int,int])` attempts to construct a `set` from the generic type `tuple[int,int]`. Instead, `set[tuple[int,int]]` will construct [a type](https://peps.python.org/pep-0585/).