### PR TITLE
upgrade pydantic to 2.5.3 and zhinst 23.10.3

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -12,10 +12,10 @@ dependencies:
     - black
     - flake8
     - openpulse
-    - pydantic==1.10
+    - pydantic==2.5.3
     - pylint-pydantic
     - scipy
-    - zhinst==23.6.2
+    - zhinst==25.10.3
     - matplotlib
     - pyyaml
     - deprecated

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,8 +17,8 @@ install_requires =
     numpy
     scipy
     openpulse
-    pydantic==1.10
-    zhinst==23.6.2
+    pydantic==2.5.3
+    zhinst==23.10.3
     matplotlib
     pyyaml
     deprecated

--- a/shipyard/mangle.py
+++ b/shipyard/mangle.py
@@ -183,8 +183,8 @@ class FunctionSignature(BaseModel):
     """
 
     name: str
-    params: list[str] = Field(default_factory=lambda: [])
-    qubits: list[str] = Field(default_factory=lambda: [])
+    params: list[str | None] = Field(default_factory=lambda: [])
+    qubits: list[str | None] = Field(default_factory=lambda: [])
     return_type: str = ""
 
     def mangle(self) -> str:
@@ -284,7 +284,7 @@ class FunctionSignature(BaseModel):
 class Mangler(LiteralVisitor, TypeVisitor, GenericVisitor):
     """
     QASMVisitor that visits CalibrationDefinition or QuantumGate nodes to gather
-    the iformation required to mangle function definition signatures and function calls
+    the information required to mangle function definition signatures and function calls
     """
 
     def __init__(

--- a/shipyard/passes/semantic_analysis/builtin_functions.py
+++ b/shipyard/passes/semantic_analysis/builtin_functions.py
@@ -18,7 +18,7 @@ for zi:seqc based on
 import json
 from pathlib import Path
 
-from pydantic import BaseModel, Field, validator
+from pydantic import BaseModel, Field, validator, field_validator
 
 from .symbols import ClassicalSymbol, ExternSymbol
 
@@ -48,9 +48,9 @@ class FunctionSignature(BaseModel):
     """
 
     inputs: dict[str, str] = Field(default_factory=lambda: {})
-    return_type: str = None
+    return_type: str | None = None
 
-    @validator("inputs")
+    @field_validator("inputs")
     def make_input_type_upper_case(cls, inputs: dict[str, str]):
         """Ensures that the type names are uppercase such that thay match
         the symbol names for built in type (see symbols.py for details)

--- a/shipyard/setup/external.py
+++ b/shipyard/setup/external.py
@@ -148,7 +148,7 @@ class SetupExternal(BaseModel):
         path = Path(path)
         match path.suffix:
             case ".json":
-                setup = cls.parse_file(path)
+                setup = cls.model_validate_json(path.read_text(encoding="utf-8"))
             case ".yml":
                 setup = cls(**yaml.safe_load(path.read_text(encoding="utf-8")))
             case _:
@@ -180,9 +180,9 @@ class SetupExternal(BaseModel):
         path = Path(path)
         match path.suffix:
             case ".json":
-                path.write_text(self.json(), encoding="utf-8")
+                path.write_text(self.model_dump_json(), encoding="utf-8")
             case ".yml":
-                path.write_text(yaml.dump(self.dict()), encoding="utf-8")
+                path.write_text(yaml.dump(self.model_dump()), encoding="utf-8")
             case _:
                 raise ValueError(f"Unknown file extension: {path.suffix}")
         return path
@@ -364,7 +364,7 @@ class SetupExternal(BaseModel):
         Returns:
             SetupInternal: internal setup representation
         """
-        return SetupInternal.from_dict(self.dict())
+        return SetupInternal.from_dict(self.model_dump())
 
     @classmethod
     def from_internal(cls, internal: SetupInternal) -> "SetupExternal":

--- a/shipyard/setup/internal.py
+++ b/shipyard/setup/internal.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 import yaml
-from pydantic import BaseModel, validator
+from pydantic import BaseModel, validator, field_validator
 
 from ..awg_core import CORE_TYPE_TO_CLASS, AWGCore, CoreType
 from ..duration import Duration
@@ -83,15 +83,15 @@ class Port(BaseModel):
             """
             return CORE_TYPE_TO_CLASS[self.type]
 
-        @validator("channels")
+        @field_validator("channels")
         def not_more_channels_than_core_type_allows(cls, channels: list[int], values):
             """
             Validates that the number of channels for the Core object does
             not exceed the number of channels allowed by the CoreType
             """
             assert channels
-            assert "type" in values
-            assert len(channels) <= CORE_TYPE_TO_CLASS[values["type"]].n_channels
+            assert "type" in values.data
+            assert len(channels) <= CORE_TYPE_TO_CLASS[values.data["type"]].n_channels
             return channels
 
     name: str


### PR DESCRIPTION
For the use of the shipyard with other recent python modules,
upgrading pydantic dependency to version 2 was required.
I also upgraded the zhinst dependency to 25.10.3.